### PR TITLE
Load html snippets in typescriptreact

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
           "pug",
           "eruby",
           "javascriptreact",
+          "typescriptreact",
           "htmldjango",
           "astro"
         ],


### PR DESCRIPTION
Currently not getting html snippets in .tsx files, and extending the typescriptreact filetype with html causes duplicate entries for global snippets such as LoremIpsum being in both "all" and "html".